### PR TITLE
Close prepared queries

### DIFF
--- a/mysqlconn_wrapper.cpp
+++ b/mysqlconn_wrapper.cpp
@@ -80,8 +80,14 @@ void MySQLConnWrapper::setString(const int& num, const string& data)
 
 void MySQLConnWrapper::execute(const string& query)
 {
-    try{
-        res = (query != "") ? stmt->executeQuery(query) : prep_stmt->executeQuery();
+
+    try {
+    	if (query != "") {
+    		res = stmt->executeQuery(query);
+    	} else {
+    		res = prep_stmt->executeQuery();
+    		prep_stmt->close();
+    	}
     } catch (sql::SQLException &e) {
         manageException(e);
     }


### PR DESCRIPTION
If the wrapper is used in a daemon that makes many (by default 16382) prepared database writes without disconnecting, the MySql database will eventually crash with an `Can’t create more than max_prepared_stmt_count statements` error message.

We only need to close the prepared statement, other statement types don't stay open, so I've exploded the `if` statement to clearly show the added extra line.

An example of the problem is given online - https://iammysql.wordpress.com/2012/05/04/cant-create-more-than-max_prepared_stmt_count-statements/
