### PR TITLE
Allow for SQL commands and not just queries

### DIFF
--- a/mysqlconn_wrapper.cpp
+++ b/mysqlconn_wrapper.cpp
@@ -80,15 +80,23 @@ void MySQLConnWrapper::setString(const int& num, const string& data)
 
 void MySQLConnWrapper::execute(const string& query)
 {
+    try{
+	stmt->execute(query);
+    } catch (sql::SQLException &e){
+        manageException(e);
+    }
+}
 
-    try {
-    	if (query != "") {
+void MySQLConnWrapper::query(const string& query)
+{
+    try{
+    	if (query != ""){
     		res = stmt->executeQuery(query);
-    	} else {
+    	} else{
     		res = prep_stmt->executeQuery();
     		prep_stmt->close();
     	}
-    } catch (sql::SQLException &e) {
+    } catch (sql::SQLException &e){
         manageException(e);
     }
 }


### PR DESCRIPTION
The current wrapper only allows (expects) queries, not commands, so TRUNCATE, DROP, CREATE are not available.

Added a `stmt->execute(query)` call to fix.

This pull has renamed the excising 'execute' to 'query' and might not be preferable, required excising code to be changed if updated with this. It might be better to keep the 'execute' name as is and create the new as 'command' or something?

Also the header file will need updating. ;-)
